### PR TITLE
Modified activity_tutorial.xml,tutorial_slide1.xml and colors.xml

### DIFF
--- a/app/src/main/res/layout/activity_tutorial.xml
+++ b/app/src/main/res/layout/activity_tutorial.xml
@@ -33,7 +33,7 @@
         android:layout_alignParentRight="true"
         android:background="@null"
         android:text="@string/next"
-        android:textColor="@android:color/white" />
+        android:textColor="@color/black" />
 
 
 </RelativeLayout>

--- a/app/src/main/res/layout/tutorial_slide1.xml
+++ b/app/src/main/res/layout/tutorial_slide1.xml
@@ -17,7 +17,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/slide1_heading"
-            android:textColor="@android:color/white"
+            android:textColor="@color/black"
             android:textSize="@dimen/slide_title"
             android:textStyle="bold" />
 
@@ -35,7 +35,7 @@
             android:text="@string/slide1_text"
             android:textAlignment="center"
             android:gravity="center"
-            android:textColor="@android:color/white"
+            android:textColor="@color/black"
             android:textSize="@dimen/slide_desc" />
 
     </LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -10,6 +10,7 @@
     <color name="lightgrey">#AAFFFFFF</color>
     <color name="white">#fafafa</color>
     <color name="red">#d01530</color>
+    <color name="black">#000000</color>
     <color name="lightred">#fa7972</color>
     <color name="violet">#779461c9</color>
     <color name="yellow">#f8f49f</color>


### PR DESCRIPTION
I just noticed a color-related issue. The text of some content is white, which results in insufficient color contrast and makes it very difficult to read. Therefore, it should be changed to black.

before：
![9b](https://github.com/user-attachments/assets/641b7d90-b97a-4223-9f4e-cffc484a203d)

after：
![9a](https://github.com/user-attachments/assets/b618c892-e80c-4e6f-9fd7-082847344518)
